### PR TITLE
fix `bold highlighting of text` in Learn section for Linear Regression problem (Gradient Descent)

### DIFF
--- a/Problems/15_linear_regression_gradient_descent/learn.html
+++ b/Problems/15_linear_regression_gradient_descent/learn.html
@@ -20,7 +20,7 @@
 <li>\(x_j^{(i)}\) is the value of feature \(j\) for the \(i^{th}\) training example.</li>
 </ul>
 
-<p>**Things to note**: The choice of learning rate and the number of iterations are crucial for the convergence and performance of gradient descent. Too small a learning rate may lead to slow convergence, while too large a learning rate may cause overshooting and divergence.</p>
+<p><b>Things to note</b>: The choice of learning rate and the number of iterations are crucial for the convergence and performance of gradient descent. Too small a learning rate may lead to slow convergence, while too large a learning rate may cause overshooting and divergence.</p>
 
 <h3>Practical Implementation</h3>
 


### PR DESCRIPTION
Made changes to the html file `Problems\15_linear_regression_gradient_descent` which reflects a typo in highlighting(bold) of a text heading [Linear Regression Using Gradient Descent](https://www.deep-ml.com/problem/Linear%20Regression%20Using%20Gradient%20Descent).

Changes made:

Before:
```
<p>**Things to note**: The choice of learning rate and the number of iterations are crucial for the convergence and performance of gradient descent. Too small a learning rate may lead to slow convergence, while too large a learning rate may cause overshooting and divergence.</p>

```

After:
```
<p><b>Things to note</b>: The choice of learning rate and the number of iterations are crucial for the convergence and performance of gradient descent. Too small a learning rate may lead to slow convergence, while too large a learning rate may cause overshooting and divergence.</p>

```