### PR TITLE
modify Q48: current solution cannot handle "0 at diagonal" circumstance

### DIFF
--- a/Problems/48_rref/learn.html
+++ b/Problems/48_rref/learn.html
@@ -8,7 +8,7 @@
 <p>Set the initial leading column to the first column of the matrix. We'll move this "lead" to the right as we progress through the algorithm.</p>
 
 <h3>2. Select the pivot row</h3>
-<p>Identify the first non-zero entry in the current leading column. This entry is known as the pivot. If necessary, swap the current row with the row containing the pivot to bring the pivot into the leading position.</p>
+<p>Identify the first non-zero entry in the current leading column. This entry is known as the pivot. If necessary, add the row containing the pivot to the current row to avoid it being zero.</p>
 
 <h3>3. Scale the pivot row</h3>
 <p>Divide the entire pivot row by the pivot value to make the leading entry equal to 1.</p>

--- a/Problems/48_rref/solution.py
+++ b/Problems/48_rref/solution.py
@@ -15,33 +15,6 @@ def rref(matrix):
 
     return A
 
-# def rref(matrix):
-#     # Convert to float for division operations
-#     A = np.array(matrix, dtype=float)
-#     m, n = A.shape
-    
-#     lead = 0
-#     for r in range(m):
-#         if lead >= n:
-#             return A
-#         i = r
-#         while A[i, lead] == 0:
-#             i += 1
-#             if i == m:
-#                 i = r
-#                 lead += 1
-#                 if n == lead:
-#                     return A
-#         A[i], A[r] = A[r], A[i]
-#         lv = A[r, lead]
-#         A[r] = A[r] / lv
-#         for i in range(m):
-#             if i != r:
-#                 lv = A[i, lead]
-#                 A[i] = A[i] - lv * A[r]
-#         lead += 1
-#     return A
-
 def test_rref():
     # Test case 1
     matrix = np.array([

--- a/Problems/48_rref/solution.py
+++ b/Problems/48_rref/solution.py
@@ -7,7 +7,11 @@ def rref(matrix):
     
     for i in range(n):
         if A[i, i] == 0:
-            A[i] = A[i] + A[(A[i:, 0] != 0).argmax(), ]
+            nonzero_rel_id = np.nonzero(A[i:, i])[0]
+            if len(nonzero_rel_id) == 0: continue
+            
+            A[i] = A[i] + A[nonzero_rel_id[0] + i]
+
         A[i] = A[i] / A[i, i]
         for j in range(n):
             if i != j:
@@ -54,6 +58,18 @@ def test_rref():
         [-0., -0.,  1., -11.]
     ])
     assert np.allclose(rref(matrix), expected_output), "Test case 3 failed"
+    
+   # Test case 4
+    matrix = np.array([
+        [1, 2, -1],
+        [2, 4, -1],
+        [-2, -4, -3]])
+    expected_output = np.array([
+        [ 1.,  2.,  0.],
+        [ 0.,  0.,  0.],
+        [-0., -0.,  1.]
+    ])
+    assert np.allclose(rref(matrix), expected_output), "Test case 4 failed"
 
 if __name__ == "__main__":
     test_rref()

--- a/Problems/48_rref/solution.py
+++ b/Problems/48_rref/solution.py
@@ -2,30 +2,45 @@ import numpy as np
 
 def rref(matrix):
     # Convert to float for division operations
-    A = np.array(matrix, dtype=float)
-    m, n = A.shape
+    A = matrix.astype(np.float32)
+    n, m = A.shape
     
-    lead = 0
-    for r in range(m):
-        if lead >= n:
-            return A
-        i = r
-        while A[i, lead] == 0:
-            i += 1
-            if i == m:
-                i = r
-                lead += 1
-                if n == lead:
-                    return A
-        A[i], A[r] = A[r], A[i]
-        lv = A[r, lead]
-        A[r] = A[r] / lv
-        for i in range(m):
-            if i != r:
-                lv = A[i, lead]
-                A[i] = A[i] - lv * A[r]
-        lead += 1
+    for i in range(n):
+        if A[i, i] == 0:
+            A[i] = A[i] + A[(A[i:, 0] != 0).argmax(), ]
+        A[i] = A[i] / A[i, i]
+        for j in range(n):
+            if i != j:
+                A[j] -= A[j, i] * A[i]
+
     return A
+
+# def rref(matrix):
+#     # Convert to float for division operations
+#     A = np.array(matrix, dtype=float)
+#     m, n = A.shape
+    
+#     lead = 0
+#     for r in range(m):
+#         if lead >= n:
+#             return A
+#         i = r
+#         while A[i, lead] == 0:
+#             i += 1
+#             if i == m:
+#                 i = r
+#                 lead += 1
+#                 if n == lead:
+#                     return A
+#         A[i], A[r] = A[r], A[i]
+#         lv = A[r, lead]
+#         A[r] = A[r] / lv
+#         for i in range(m):
+#             if i != r:
+#                 lv = A[i, lead]
+#                 A[i] = A[i] - lv * A[r]
+#         lead += 1
+#     return A
 
 def test_rref():
     # Test case 1
@@ -53,6 +68,19 @@ def test_rref():
         [ 0.,  0.,  1.]
     ])
     assert np.allclose(rref(matrix), expected_output), "Test case 2 failed"
+    
+    # Test case 3
+    matrix = np.array([
+        [0, 2, -1, -4],
+        [2, 0, -1, -11],
+        [-2, 0, 0, 22]
+    ])
+    expected_output = np.array([
+        [ 1.,  0.,  0., -11.],
+        [-0.,  1.,  0., -7.5],
+        [-0., -0.,  1., -11.]
+    ])
+    assert np.allclose(rref(matrix), expected_output), "Test case 3 failed"
 
 if __name__ == "__main__":
     test_rref()


### PR DESCRIPTION
current solution cannot handle "0 at diagonal" circumstance, since `A[i], A[r] = A[r], A[i]` cannot complete the swap operation indeed.

I add the test instance generating errors given the former solution, and a simpler method I proposed in `solution.py`. I also modify some contents in learn.html accordingly.