### PR TITLE
Modify Q33

### DIFF
--- a/Problems/33_random_subsets/solution.py
+++ b/Problems/33_random_subsets/solution.py
@@ -2,37 +2,25 @@ import numpy as np
 
 def get_random_subsets(X, y, n_subsets, replacements=True, seed=42):
     np.random.seed(seed)
-    n_samples = np.shape(X)[0]
-    # Concatenate X and y and do a random shuffle
-    X_y = np.concatenate((X, y.reshape((len(y), 1))), axis=1)
-    np.random.shuffle(X_y)
-    subsets = []
-
-    # Determine subsample size
-    subsample_size = n_samples if replacements else n_samples // 2
-
-    for _ in range(n_subsets):
-        idx = np.random.choice(
-            range(n_samples),
-            size=subsample_size,
-            replace=replacements)
-        X_subset = X_y[idx][:, :-1]
-        y_subset = X_y[idx][:, -1]
-        subsets.append([X_subset, y_subset])
-    return subsets
+    n, m = X.shape
+    
+    subset_size = n if replacements else n // 2
+    idx = np.array([np.random.choice(n, subset_size, replace=replacements) for _ in range(n_subsets)])
+    # convert all ndarrays to lists
+    return [[X[idx][i].tolist(), y[idx][i].tolist()] for i in range(n_subsets)]
 
 def test_get_random_subsets():
     # Test case 1
     X = np.array([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]])
     y = np.array([1, 2, 3, 4, 5])
-    expected_output = [[[1, 2], [9, 10]], [1, 5]]
-    assert np.array_equal(get_random_subsets(X, y, 1, False, seed=42), expected_output), "Test case 1 failed"
+    expected_output = [[[[3, 4], [9, 10]], [2, 5]], [[[7, 8], [3, 4]], [4, 2]], [[[3, 4], [1, 2]], [2, 1]]]
+    assert get_random_subsets(X, y, 3, False, seed=42) == expected_output, "Test case 1 failed"
     
     # Test case 2
     X = np.array([[1, 1], [2, 2], [3, 3], [4, 4]])
     y = np.array([10, 20, 30, 40])
-    expected_output = [[[1, 1], [3, 3], [2, 2], [2, 2]], [10, 30, 20, 20]]
-    assert np.array_equal(get_random_subsets(X, y, 1, True, seed=42), expected_output), "Test case 2 failed"
+    expected_output = [[[[3, 3], [4, 4], [1, 1], [3, 3]], [30, 40, 10, 30]]]
+    assert get_random_subsets(X, y, 1, True, seed=42) == expected_output, "Test case 2 failed"
 
 if __name__ == "__main__":
     test_get_random_subsets()

--- a/Problems/33_random_subsets/solution.py
+++ b/Problems/33_random_subsets/solution.py
@@ -7,19 +7,19 @@ def get_random_subsets(X, y, n_subsets, replacements=True, seed=42):
     subset_size = n if replacements else n // 2
     idx = np.array([np.random.choice(n, subset_size, replace=replacements) for _ in range(n_subsets)])
     # convert all ndarrays to lists
-    return [[X[idx][i].tolist(), y[idx][i].tolist()] for i in range(n_subsets)]
+    return [(X[idx][i].tolist(), y[idx][i].tolist()) for i in range(n_subsets)]
 
 def test_get_random_subsets():
     # Test case 1
     X = np.array([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]])
     y = np.array([1, 2, 3, 4, 5])
-    expected_output = [[[[3, 4], [9, 10]], [2, 5]], [[[7, 8], [3, 4]], [4, 2]], [[[3, 4], [1, 2]], [2, 1]]]
+    expected_output = [([[3, 4], [9, 10]], [2, 5]), ([[7, 8], [3, 4]], [4, 2]), ([[3, 4], [1, 2]], [2, 1])]
     assert get_random_subsets(X, y, 3, False, seed=42) == expected_output, "Test case 1 failed"
     
     # Test case 2
     X = np.array([[1, 1], [2, 2], [3, 3], [4, 4]])
     y = np.array([10, 20, 30, 40])
-    expected_output = [[[[3, 3], [4, 4], [1, 1], [3, 3]], [30, 40, 10, 30]]]
+    expected_output = [([[3, 3], [4, 4], [1, 1], [3, 3]], [30, 40, 10, 30])]
     assert get_random_subsets(X, y, 1, True, seed=42) == expected_output, "Test case 2 failed"
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. For the old solution of Q33, we do not need to shuffle before `np.choice()`, solution modified.
2. For the test cases, we only have 1 subset case, and do not have more than 1 cases. Modify test case 1 into 3 subsets.
3. There are problems with the form of expected outputs (1 dimension lost). And also we cannot use `np.array_equal()` to compare the arrays, since the dimensions of the result are not consistent. For example, `([[1,2],[3,4]], [1,4])`.
I modified the expected output, and change the comparing approach into simple `==` (But in this case, we have to mention in the question that the form of the results in the tuple should also be lists instead of ndarrays)