### PR TITLE
Problem7 testcase4 bugfix

### DIFF
--- a/Problems/7_transform_matrix/solution.py
+++ b/Problems/7_transform_matrix/solution.py
@@ -46,8 +46,8 @@ def test_transform_matrix() -> None:
     
     # Test case 4
     A = [[2, 3], [1, 4]]
-    T = [[3, 0], [0, 3]]
-    S = [[1, 1], [1, 1]]
+    T = [[1, 1], [1, 1]]
+    S = [[3, 0], [0, 3]]
     assert transform_matrix(A, T, S) == -1
     # try:
     #     transform_matrix(A, T, S)

--- a/Problems/7_transform_matrix/solution.py
+++ b/Problems/7_transform_matrix/solution.py
@@ -12,7 +12,7 @@ def transform_matrix(
     S = np.array(S, dtype=float)
     
     # Check if the matrices T and S are invertible
-    if np.linalg.det(T) == 0 or np.linalg.det(S) == 0:
+    if np.linalg.det(T) == 0:
         # raise ValueError("The matrices T and/or S are not invertible.")
         return -1
     


### PR DESCRIPTION
# Problem

![image](https://github.com/user-attachments/assets/3fd45135-0443-49ea-9dc4-b7c371c4424d)

Where the equation does not need S to be invertible. Which causes further confusion in the "learn about this topic" page. Where they only check for invertibility of T because that's the only place its necessary to solve the equation. 

![image](https://github.com/user-attachments/assets/bb15a4c8-620e-405c-a967-c2317218fec5)
![image](https://github.com/user-attachments/assets/8f72d8f5-98f4-4f6e-a283-cec7177d1273)

# solution

- Remove check for invertibility of S
- change problem 4 edge case to make T determinant 0. 
- Also change verbiage of the problem to reflect that only T needs invertibility check. (Not possible through PR I think?) 