### PR TITLE
Fix type handling issues in `ELU` activation function

### DIFF
--- a/questions/97_implement-the-elu-activation-function/example.json
+++ b/questions/97_implement-the-elu-activation-function/example.json
@@ -1,5 +1,5 @@
 {
   "input": "elu(-1)",
-  "output": "-0.6321",
+  "output": "-0.6321205588285577",
   "reasoning": "For x = -1 and alpha = 1.0, the ELU activation is computed as $\\alpha(e^x - 1)$."
 }

--- a/questions/97_implement-the-elu-activation-function/solution.py
+++ b/questions/97_implement-the-elu-activation-function/solution.py
@@ -11,4 +11,4 @@ def elu(x: float, alpha: float = 1.0) -> float:
     Returns:
         float: ELU activation value
     """
-    return round(x if x > 0 else alpha * (math.exp(x) - 1),4)
+    return x if x > 0 else alpha * (math.exp(x) - 1)

--- a/questions/97_implement-the-elu-activation-function/starter_code.py
+++ b/questions/97_implement-the-elu-activation-function/starter_code.py
@@ -11,4 +11,3 @@ def elu(x: float, alpha: float = 1.0) -> float:
 	"""
 	# Your code here
 	pass
-	return round(val,4)

--- a/questions/97_implement-the-elu-activation-function/tests.json
+++ b/questions/97_implement-the-elu-activation-function/tests.json
@@ -5,22 +5,22 @@
   },
   {
     "test": "print(elu(1))",
-    "expected_output": "1.0"
+    "expected_output": "1"
   },
   {
     "test": "print(elu(-1))",
-    "expected_output": "-0.6321"
+    "expected_output": "-0.6321205588285577"
   },
   {
     "test": "print(elu(-1, alpha=2.0))",
-    "expected_output": "-1.2642"
+    "expected_output": "-1.2642411176571153"
   },
   {
     "test": "print(elu(5))",
-    "expected_output": "5.0"
+    "expected_output": "5"
   },
   {
     "test": "print(elu(-5))",
-    "expected_output": "-0.9933"
+    "expected_output": "-0.9932620530009145"
   }
 ]


### PR DESCRIPTION
@kurpenok Hey! Sorry for the late response on this one. 

Fixed the type inconsistencies you mentioned; removed the unnecessary `round()` calls that were causing problems. The function now returns exact math values (expected test cases).

Should work properly now without those. Thanks for the screenshots!