### PR TITLE
enhanced the test case

### DIFF
--- a/questions/67_implement-compressed-column-sparse-matrix-format-c/tests.json
+++ b/questions/67_implement-compressed-column-sparse-matrix-format-c/tests.json
@@ -1,14 +1,14 @@
 [
   {
-    "test": "dense_matrix = [\n    [0, 0, 0],\n    [0, 0, 0],\n    [0, 0, 0]\n]\nvals, row_idx, col_ptr = compressed_col_sparse_matrix(dense_matrix)\nprint(vals)",
-    "expected_output": "[]"
+    "test": "dense_matrix = [\n    [0, 0, 0],\n    [0, 0, 0],\n    [0, 0, 0]\n]\nvals, row_idx, col_ptr = compressed_col_sparse_matrix(dense_matrix)\nprint(vals)\nprint(row_idx)\nprint(col_ptr)",
+    "expected_output": "[]\n[]\n[0, 0, 0, 0]"
   },
   {
-    "test": "dense_matrix = [\n    [0, 0, 0],\n    [1, 2, 0],\n    [0, 3, 4]\n]\nvals, row_idx, col_ptr = compressed_col_sparse_matrix(dense_matrix)\nprint(vals)",
-    "expected_output": "[1, 2, 3, 4]"
+    "test": "dense_matrix = [\n    [0, 0, 0],\n    [1, 2, 0],\n    [0, 3, 4]\n]\nvals, row_idx, col_ptr = compressed_col_sparse_matrix(dense_matrix)\nprint(vals)\nprint(row_idx)\nprint(col_ptr)",
+    "expected_output": "[1, 2, 3, 4]\n[1, 1, 2, 2]\n[0, 1, 3, 4]"
   },
   {
-    "test": "dense_matrix = [\n    [0, 0, 3, 0, 0],\n    [0, 4, 0, 0, 0],\n    [5, 0, 0, 6, 0],\n    [0, 0, 0, 0, 0],\n    [0, 7, 0, 0, 8]\n]\nvals, row_idx, col_ptr = compressed_col_sparse_matrix(dense_matrix)\nprint(vals)",
-    "expected_output": "[5, 4, 7, 3, 6, 8]"
+    "test": "dense_matrix = [\n    [0, 0, 3, 0, 0],\n    [0, 4, 0, 0, 0],\n    [5, 0, 0, 6, 0],\n    [0, 0, 0, 0, 0],\n    [0, 7, 0, 0, 8]\n]\nvals, row_idx, col_ptr = compressed_col_sparse_matrix(dense_matrix)\nprint(vals)\nprint(row_idx)\nprint(col_ptr)",
+    "expected_output": "[5, 4, 7, 3, 6, 8]\n[2, 1, 4, 0, 2, 4]\n[0, 1, 3, 4, 5, 6]"
   }
 ]


### PR DESCRIPTION
Updated `test.json` to include complete validation of the `compressed_col_sparse_matrix` function output.

Previously, the tests were only checking the `vals` output. I have now modified the tests to also print and validate the `row_idx` and `col_ptr` outputs. This ensures comprehensive correctness of the compressed column format representation.

Changes made
For each test case, added `print(row_idx)` and `print(col_ptr)` after `print(vals)`.

Updated the corresponding expected_output to include all three returned values: `vals`, `row_idx`, and `col_ptr`.