### PR TITLE
feat(question): Add gradient accumulation test for shared computation graph nodes

### DIFF
--- a/questions/26_implementing-basic-autograd-operations/tests.json
+++ b/questions/26_implementing-basic-autograd-operations/tests.json
@@ -2,5 +2,9 @@
   {
     "test": "a = Value(2);b = Value(3);c = Value(10);d = a + b * c  ;e = Value(7) * Value(2);f = e + d;g = f.relu()  \ng.backward()\nprint(a,b,c,d,e,f,g)\n",
     "expected_output": " Value(data=2, grad=1) Value(data=3, grad=10) Value(data=10, grad=3) Value(data=32, grad=1) Value(data=14, grad=1) Value(data=46, grad=1) Value(data=46, grad=1)"
+  },
+  {
+    "test": "a = Value(2); b = Value(3); c = Value(10); d = a * c; e = b * c; g = d + e; g.backward(); print(a, b, c, d, e)",
+    "expected_output": "Value(data=2, grad=10) Value(data=3, grad=10) Value(data=10, grad=5) Value(data=20, grad=1) Value(data=30, grad=1)"
   }
 ]


### PR DESCRIPTION
- Introduced test case where a single node (c) contributes to multiple branches
- Ensures gradients are accumulated using += instead of overwritten
- Validates correct backprop behavior in diamond-shaped computation graphs