### PR TITLE
Fix problem 85  positional encoding example (Issue #495)

### DIFF
--- a/questions/85_positional-encoding-calculator/example.json
+++ b/questions/85_positional-encoding-calculator/example.json
@@ -1,5 +1,5 @@
 {
   "input": "position = 2, d_model = 8",
-  "reasoning": "The function computes the positional encoding by calculating sine values for even indices and cosine values for odd indices, ensuring that the encoding provides the required positional information.",
-  "output": "[[[ 0.,0.,0.,0.,1.,1.,1.,1.,]\n  [ 0.8413,0.0998,0.01,0.001,0.5405,0.995,1.,1.]]]"
+  "reasoning": "The function computes the positional encoding by applying sine to even indices and cosine to odd indices, as specified in the original Transformer architecture.",
+  "output": "[[0., 1., 0., 1., 0., 1., 0., 1.],\n [0.8413, 0.5405, 0.0999, 0.995, 0.01, 1., 0.001, 1.]]"
 }


### PR DESCRIPTION
## Summary

This PR fixes the example for **Problem 85: Positional Encoding Calculator**.

## Changes

* Corrected the example output to match the standard sinusoidal positional encoding described in the original Transformer architecture.
* Fixed the ordering of sine and cosine values (sine at even indices and cosine at odd indices).
* Removed the incorrect extra array dimension from the sample output.
* Updated the reasoning to accurately describe how positional encoding is computed.

## Verification

The corrected example output was regenerated using the reference implementation of the positional encoding algorithm.

**Correct output generated by the implementation:**

<img width="843" height="602" alt="Generated positional encoding output" src="https://github.com/user-attachments/assets/c7b24318-99dc-476d-a54c-1148082c4846" />

**Current example displayed on the website:**

<img width="848" height="386" alt="Current example on website" src="https://github.com/user-attachments/assets/2bda71fe-fb9f-4d7b-ab9f-1d24bcbb2f66" />

Closes #495
